### PR TITLE
ci: re-enable trivy security scanning in release workflows

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -66,3 +66,68 @@ jobs:
         ${{ needs.extract-version.outputs.debezium_version }}
         latest
     secrets: inherit
+
+  trivy-scan:
+    needs: [extract-version, release]
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Manual Trivy Setup
+        uses: aquasecurity/setup-trivy@v0.2.5
+        with:
+          version: v0.69.2
+          cache: true
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@0.34.1
+        with:
+          version: v0.69.2
+          skip-setup-trivy: true
+          image-ref: ${{ vars.DOCKERHUB_USERNAME }}/debezium-alpine-base:${{ needs.extract-version.outputs.debezium_version }}
+          format: "sarif"
+          output: "trivy-results-debezium-alpine-base.sarif"
+          exit-code: "0"
+          ignore-unfixed: true
+          vuln-type: "os,library"
+          severity: "CRITICAL,HIGH,MEDIUM,LOW"
+          trivyignores: ".trivyignore"
+        env:
+          TRIVY_DISABLE_VEX_NOTICE: true
+
+      - name: Edit Trivy Sarif result
+        run: |
+          jq ".runs[0].tool.driver.name = \"Trivy-image-debezium-alpine-base\"" ./trivy-results-debezium-alpine-base.sarif > ./trivy-results-debezium-alpine-base-edited.sarif
+
+      - name: Upload Trivy Sarif result
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: "trivy-results-debezium-alpine-base-edited.sarif"
+          category: Trivy-docker-debezium-alpine-base
+
+      - name: Trivy vulnerability block Critical
+        uses: aquasecurity/trivy-action@0.34.1
+        with:
+          version: v0.69.2
+          skip-setup-trivy: true
+          image-ref: ${{ vars.DOCKERHUB_USERNAME }}/debezium-alpine-base:${{ needs.extract-version.outputs.debezium_version }}
+          format: "json"
+          exit-code: 1
+          ignore-unfixed: true
+          vuln-type: "os,library"
+          severity: "CRITICAL"
+          trivyignores: ".trivyignore"
+        env:
+          TRIVY_DISABLE_VEX_NOTICE: true

--- a/.github/workflows/connect-base.yml
+++ b/.github/workflows/connect-base.yml
@@ -94,3 +94,68 @@ jobs:
         ${{ needs.extract-version.outputs.debezium_version }}
         latest
     secrets: inherit
+
+  trivy-scan:
+    needs: [extract-version, release]
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Manual Trivy Setup
+        uses: aquasecurity/setup-trivy@v0.2.5
+        with:
+          version: v0.69.2
+          cache: true
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@0.34.1
+        with:
+          version: v0.69.2
+          skip-setup-trivy: true
+          image-ref: ${{ vars.DOCKERHUB_USERNAME }}/debezium-alpine-connect-base:${{ needs.extract-version.outputs.debezium_version }}
+          format: "sarif"
+          output: "trivy-results-debezium-alpine-connect-base.sarif"
+          exit-code: "0"
+          ignore-unfixed: true
+          vuln-type: "os,library"
+          severity: "CRITICAL,HIGH,MEDIUM,LOW"
+          trivyignores: ".trivyignore"
+        env:
+          TRIVY_DISABLE_VEX_NOTICE: true
+
+      - name: Edit Trivy Sarif result
+        run: |
+          jq ".runs[0].tool.driver.name = \"Trivy-image-debezium-alpine-connect-base\"" ./trivy-results-debezium-alpine-connect-base.sarif > ./trivy-results-debezium-alpine-connect-base-edited.sarif
+
+      - name: Upload Trivy Sarif result
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: "trivy-results-debezium-alpine-connect-base-edited.sarif"
+          category: Trivy-docker-debezium-alpine-connect-base
+
+      - name: Trivy vulnerability block Critical
+        uses: aquasecurity/trivy-action@0.34.1
+        with:
+          version: v0.69.2
+          skip-setup-trivy: true
+          image-ref: ${{ vars.DOCKERHUB_USERNAME }}/debezium-alpine-connect-base:${{ needs.extract-version.outputs.debezium_version }}
+          format: "json"
+          exit-code: 1
+          ignore-unfixed: true
+          vuln-type: "os,library"
+          severity: "CRITICAL"
+          trivyignores: ".trivyignore"
+        env:
+          TRIVY_DISABLE_VEX_NOTICE: true

--- a/.github/workflows/final-images.yml
+++ b/.github/workflows/final-images.yml
@@ -82,3 +82,71 @@ jobs:
         ${{ fromJSON(needs.extract-versions.outputs.versions)[matrix.plugin] }}
         latest
     secrets: inherit
+
+  trivy-scan:
+    needs: [extract-versions, release]
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        plugin: [postgresql-slim, snowflake-slim, mariadb-slim, jdbc-slim]
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Manual Trivy Setup
+        uses: aquasecurity/setup-trivy@v0.2.5
+        with:
+          version: v0.69.2
+          cache: true
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@0.34.1
+        with:
+          version: v0.69.2
+          skip-setup-trivy: true
+          image-ref: ${{ vars.DOCKERHUB_USERNAME }}/debezium-${{ matrix.plugin }}:${{ fromJSON(needs.extract-versions.outputs.versions)[matrix.plugin] }}
+          format: "sarif"
+          output: "trivy-results-debezium-${{ matrix.plugin }}.sarif"
+          exit-code: "0"
+          ignore-unfixed: true
+          vuln-type: "os,library"
+          severity: "CRITICAL,HIGH,MEDIUM,LOW"
+          trivyignores: ".trivyignore"
+        env:
+          TRIVY_DISABLE_VEX_NOTICE: true
+
+      - name: Edit Trivy Sarif result
+        run: |
+          jq ".runs[0].tool.driver.name = \"Trivy-image-debezium-${{ matrix.plugin }}\"" ./trivy-results-debezium-${{ matrix.plugin }}.sarif > ./trivy-results-debezium-${{ matrix.plugin }}-edited.sarif
+
+      - name: Upload Trivy Sarif result
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: "trivy-results-debezium-${{ matrix.plugin }}-edited.sarif"
+          category: Trivy-docker-debezium-${{ matrix.plugin }}
+
+      - name: Trivy vulnerability block Critical
+        uses: aquasecurity/trivy-action@0.34.1
+        with:
+          version: v0.69.2
+          skip-setup-trivy: true
+          image-ref: ${{ vars.DOCKERHUB_USERNAME }}/debezium-${{ matrix.plugin }}:${{ fromJSON(needs.extract-versions.outputs.versions)[matrix.plugin] }}
+          format: "json"
+          exit-code: 1
+          ignore-unfixed: true
+          vuln-type: "os,library"
+          severity: "CRITICAL"
+          trivyignores: ".trivyignore"
+        env:
+          TRIVY_DISABLE_VEX_NOTICE: true

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,4 @@
+# zlib - CVE-2026-22184
+# No fix available upstream yet, re-evaluate when Alpine ships a patched package
+# https://avd.aquasec.com/nvd/2026/cve-2026-22184/
+CVE-2026-22184 exp:2026-04-15


### PR DESCRIPTION
## What

Re-adds Trivy vulnerability scanning to the release pipeline for all image workflows (`base`, `connect-base`, `final-images`). Scanning was only running on PRs — the release jobs pushing to DockerHub had no Trivy step.

## Why

The `release` jobs use `build-push-image-to-dockerhub.yml` which has no built-in Trivy support, unlike `build-image.yml` used for PRs. The gap was introduced in [fa08e7f](https://github.com/ZeroGachis/debezium-alpine/commit/fa08e7f) when per-image release workflows were added, without porting the scan step. Published images were therefore never scanned.

## Changes

- Add `trivy-scan` job after `release` in `base.yml`, `connect-base.yml`, and `final-images.yml`
  - Runs against the published DockerHub image (uses version tag, not `latest`)
  - Uploads SARIF results to GitHub Security tab
  - Blocks on CRITICAL vulnerabilities (`exit-code: 1`)
  - Scans `CRITICAL,HIGH,MEDIUM,LOW` for full visibility in SARIF
- Add `.trivyignore` at repo root to suppress `CVE-2026-22184` (zlib) with expiration `2026-04-15`, pending a patched package from Alpine upstream

## Testing

- CI will validate on this PR (PR build path via `build-image.yml` already has Trivy)
- Release path scan will be validated on merge to main